### PR TITLE
typo in env name

### DIFF
--- a/environment-win.yaml
+++ b/environment-win.yaml
@@ -1,4 +1,4 @@
-name: csb
+name: scb
 channels:
 - defaults
 - conda-forge

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,4 +1,4 @@
-name: csb
+name: scb
 channels:
 - defaults
 - conda-forge


### PR DESCRIPTION
@cjayb  I assume the name is an acronym of scientific_computing_basics 